### PR TITLE
Use year and gcc version to generate compiler archive names

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -11,11 +11,8 @@ jobs:
     steps:
     - script: |
         ./build.sh
+        cp FRC-*-Windows*.zip $BUILD_ARTIFACTSTAGINGDIRECTORY
       displayName: 'Build the image'
-    - task: CopyFiles@2
-      inputs:
-        contents: '**\windows-toolchain.zip'
-        targetFolder: $(Build.ArtifactStagingDirectory)
     - task: PublishBuildArtifacts@1
       inputs:
         artifactName: 'WindowsCompiler'
@@ -29,20 +26,16 @@ jobs:
 
         curl -O http://s.sudre.free.fr/Software/files/Iceberg.dmg
         sudo hdiutil attach Iceberg.dmg
-        ls -la "/Volumes/Iceberg 1.3.1"
         sudo installer -pkg "/Volumes/Iceberg 1.3.1/Iceberg.mpkg" -target /
         sudo hdiutil detach "/Volumes/Iceberg 1.3.1"
-
-        ./download.sh
 
         brew install wget binutils gnu-tar coreutils
         brew install gcc@6
 
+        ./download.sh
+
         chmod +x ./repack.sh
         ./repack.sh
-        echo "ran repack"
-
-        ls -la
 
         echo alias ar=gar
         echo alias tar=gtar
@@ -55,8 +48,7 @@ jobs:
 
         make gcc gdb tree pkg tarpkg
 
-        gcp *.pkg.tar.gz $BUILD_ARTIFACTSTAGINGDIRECTORY
-        gcp *Archive.tar.gz $BUILD_ARTIFACTSTAGINGDIRECTORY
+        gcp *Toolchain*.tar.gz $BUILD_ARTIFACTSTAGINGDIRECTORY
 
       displayName: 'Build the image'
     - task: PublishBuildArtifacts@1

--- a/mac/Makefile
+++ b/mac/Makefile
@@ -44,16 +44,16 @@ pkg:
 	rm -rf makes/pkg/build/
 	freeze makes/pkg/FRC\ ARM\ Toolchain.packproj
 	ls -la makes/pkg/build
-	cd makes/pkg/build && tar czf FRC\ 2019\ ARM\ Toolchain.pkg.tar.gz FRC\ 2019\ ARM\ Toolchain.pkg
-	cp makes/pkg/build/FRC\ 2019\ ARM\ Toolchain.pkg.tar.gz .
+	cd makes/pkg/build && tar czf FRC-$(V_YEAR)-Mac-Toolchain-$(V_GCC)-Installer.pkg.tar.gz FRC\ 2019\ ARM\ Toolchain.pkg
+	cp makes/pkg/build/FRC-$(V_YEAR)-Mac-Toolchain-$(V_GCC)-Installer.pkg.tar.gz .
 
 tarpkg:
 	mkdir -p frc2019
 	mkdir -p frc2019/roborio
 	rm -rf frc2019/robotio
 	cp -R tree-install/usr/local frc2019/roborio
-	tar czf FRC\ 2019\ ARM\ Toolchain\ Archive.tar.gz frc2019
+	tar czf FRC-$(V_YEAR)-Mac-Toolchain-$(V_GCC).tar.gz frc2019
 
 clean:
-	rm -rf binutils* roborio* sysroot* gcc* tree-install makes/pkg/build *.pkg.tar.gz
+	rm -rf binutils* roborio* sysroot* gcc* tree-install makes/pkg/build *.pkg.tar.gz *-Toolchain-*.tar.gz
 

--- a/windows/Makefile
+++ b/windows/Makefile
@@ -1,7 +1,7 @@
 include ../versions.sh
 
 all: clean sysroot binutils gcc gdb tree zip
-	
+
 
 sysroot:
 	rm -rf sysroot-*
@@ -13,12 +13,12 @@ sysroot:
 binutils:
 	tar xf ../binutils-$(V_BINUTILS).tar.bz2
 	V_YEAR=$(V_YEAR) V_BINUTILS=$(V_BINUTILS) makes/binutils
-	
+
 expat-install: expat
 expat:
 	tar xf ../expat-$(Vw_EXPAT).tar.bz2
 	V_YEAR=$(V_YEAR) Vw_EXPAT=$(Vw_EXPAT) makes/expat
-	
+
 gdb: expat-install
 	tar xf ../gdb-$(V_GDB).tar.gz
 	V_YEAR=$(V_YEAR) V_GDB=$(V_GDB) makes/gdb
@@ -26,12 +26,12 @@ gdb: expat-install
 gcc:
 	@# gcc does its own extraction
 	makes/gcc
-	
+
 tree:
 	V_YEAR=$(V_YEAR) V_GCC=$(V_GCC) makes/tree
-	
+
 zip:
-	cd tree-install/c/Users/Public && zip -r ../../../../windows-toolchain.zip .
+	cd tree-install/c/Users/Public && zip -r ../../../../FRC-$(V_YEAR)-Windows-Toolchain-$(V_GCC).zip .
 
 clean:
 	rm -rf binutils* roborio* sysroot* gcc* tree-install msi-build expat* gdb*


### PR DESCRIPTION
Cleaner, and easier to version during updates